### PR TITLE
model associations

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,3 +1,4 @@
 class Booking < ApplicationRecord
   belongs_to :user
+  belongs_to :wig
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,10 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :wigs
+  has_many :bookings
+  has_many :wigs, through: :bookings, as: :rented_wigs
+  has_many :wigs, as: :owned_wigs
 
-  validates :usertype, inclusion: { in: [lender, bigwig] }
+  validates :usertype, inclusion: { in: ["lender", "bigwig"] }
+
 end

--- a/app/models/wig.rb
+++ b/app/models/wig.rb
@@ -1,3 +1,5 @@
 class Wig < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, as: :owner_of_wig
+  has_many :bookings
+  has_many :users, through: :bookings, as: :renter_of_wig
 end

--- a/db/migrate/20181126170641_remove_wig_from_users.rb
+++ b/db/migrate/20181126170641_remove_wig_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveWigFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :users, :wig
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_26_142143) do
+ActiveRecord::Schema.define(version: 2018_11_26_170641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,10 +35,8 @@ ActiveRecord::Schema.define(version: 2018_11_26_142143) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "usertype"
-    t.bigint "wig_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["wig_id"], name: "index_users_on_wig_id"
   end
 
   create_table "wigs", force: :cascade do |t|
@@ -56,6 +54,5 @@ ActiveRecord::Schema.define(version: 2018_11_26_142143) do
 
   add_foreign_key "bookings", "users"
   add_foreign_key "bookings", "wigs"
-  add_foreign_key "users", "wigs"
   add_foreign_key "wigs", "users"
 end


### PR DESCRIPTION
Removed wig_id reference from User model (since 1:many reference and can get it through bookings join table)
Added wig associations  in User model and user associations to Wig model using aliases to differentiate between the two types of users.
